### PR TITLE
Set 3.19 tag for UDI in devfile

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -28,7 +28,7 @@ starterProjects:
 components:
   - name: tools
     container:
-      image:  registry.redhat.io/devspaces/udi-rhel9:3.18
+      image:  registry.redhat.io/devspaces/udi-rhel9:3.19
       memoryLimit: 1512Mi
       mountSources: true
       volumeMounts:


### PR DESCRIPTION
Since this sample is part of Dev Spaces, the devfile.yaml needs to be updated to use the correct version of the tool container image compatible with the upcoming Dev Spaces 3.19 release.

Note: The image registry.redhat.io/devspaces/udi-rhel9:3.19 will be available once Dev Spaces 3.19 is officially released. It could be tested with quay.io/devspaces/udi-rhel9:3.19 image

Related issue: https://issues.redhat.com/browse/CRW-8003
